### PR TITLE
Fix #2: subcommand を補完する

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,5 +51,24 @@ add the following to `/home/m0cchi/.emacsenv/versions/emacs-27.0.90/profiles/.em
     (setenv "HOME" (getenv "USER_HOME")))
 ```
 
+# Shell Completion
+
+## bash
+
+```bash
+$ source /path/to/emacsenv/completions/bash/emacsenv
+# or add to .bashrc:
+$ echo 'source /path/to/emacsenv/completions/bash/emacsenv' >> ~/.bashrc
+```
+
+## zsh
+
+```zsh
+$ fpath=(/path/to/emacsenv/completions/zsh $fpath)
+$ autoload -Uz compinit && compinit
+# or add to .zshrc:
+$ echo 'fpath=(/path/to/emacsenv/completions/zsh $fpath)' >> ~/.zshrc
+```
+
 # plugins
 * [emacsenv-sudo](https://github.com/m0cchi/emacsenv-sudo)

--- a/completions/bash/emacsenv
+++ b/completions/bash/emacsenv
@@ -1,0 +1,14 @@
+# bash completion for emacsenv
+
+_emacsenv() {
+    local cur prev subcommands
+    cur="${COMP_WORDS[COMP_CWORD]}"
+    prev="${COMP_WORDS[COMP_CWORD-1]}"
+    subcommands="install setup exec global local env update versions help"
+
+    if [ "$COMP_CWORD" -eq 1 ]; then
+        COMPREPLY=($(compgen -W "${subcommands}" -- "${cur}"))
+    fi
+}
+
+complete -F _emacsenv emacsenv

--- a/completions/zsh/_emacsenv
+++ b/completions/zsh/_emacsenv
@@ -1,0 +1,24 @@
+#compdef emacsenv
+
+# zsh completion for emacsenv
+
+_emacsenv() {
+    local subcommands
+    subcommands=(
+        'install:install emacs'
+        'setup:setup emacsenv'
+        'exec:exec command with emacs environment'
+        'global:set global emacs version'
+        'local:set local emacs version'
+        'env:print emacs environment variables'
+        'update:update emacsenv'
+        'versions:list installed emacs versions'
+        'help:show help'
+    )
+
+    if (( CURRENT == 2 )); then
+        _describe 'subcommand' subcommands
+    fi
+}
+
+_emacsenv


### PR DESCRIPTION
Fixes #2

## Changes
- `completions/bash/emacsenv`: bash向けのemacsenv subcommand補完スクリプトを追加
- `completions/zsh/_emacsenv`: zsh向けのemacsenv subcommand補完スクリプトを追加
- `README.md`: 補完スクリプトのセットアップ方法を追記

## Subcommands
補完対象のsubcommand: `install`, `setup`, `exec`, `global`, `local`, `env`, `update`, `versions`, `help`

## Setup

### bash
\`\`\`bash
source /path/to/emacsenv/completions/bash/emacsenv
\`\`\`

### zsh
\`\`\`zsh
fpath=(/path/to/emacsenv/completions/zsh $fpath)
autoload -Uz compinit && compinit
\`\`\`