### PR TITLE
Fix #4: feedback 強化

### DIFF
--- a/bin/emacsenv.d/_functions.sh
+++ b/bin/emacsenv.d/_functions.sh
@@ -23,7 +23,7 @@ function check_error() {
 function action() {
     echo "$(date '+%H:%M:%S'): $1" >> $LOG_DIR/$COMMAND`date '+%Y%m%d'`.log
     if [ "$1" = "" ]; then
-        echo "none action"
+        echo "emacsenv: no action specified" >&2
         if type finalize 1>/dev/null 2>/dev/null; then
             finalize $*
         fi

--- a/bin/emacsenv.d/env.sh
+++ b/bin/emacsenv.d/env.sh
@@ -1,6 +1,7 @@
 ENV_FILE=$(search_envfile)
 
 if [ "$ENV_FILE" = "" ]; then
+    echo "emacsenv: no environment file found. Run 'emacsenv global <version>' or create a .emacsenvfile" >&2
     exit 1
 fi
 

--- a/bin/emacsenv.d/exec.sh
+++ b/bin/emacsenv.d/exec.sh
@@ -1,6 +1,7 @@
 ENV_FILE=$(search_envfile)
 
 if [ "$ENV_FILE" = "" ]; then
+    echo "emacsenv: no environment file found. Run 'emacsenv global <version>' or create a .emacsenvfile" >&2
     exit 1
 fi
 
@@ -8,6 +9,7 @@ EMACS_HOME=""
 . $ENV_FILE
 
 if [ "$EMACS_HOME" = "" ]; then
+    echo "emacsenv: EMACS_HOME is not set in $ENV_FILE" >&2
     exit 1
 fi
 
@@ -17,6 +19,7 @@ shift 1
 BIN_FILE="$EMACS_HOME/bin/$target"
 
 if [ ! -e "$BIN_FILE" ]; then
+    echo "emacsenv: binary not found: $BIN_FILE" >&2
     exit 1
 fi
 

--- a/bin/emacsenv.d/import.sh
+++ b/bin/emacsenv.d/import.sh
@@ -1,6 +1,7 @@
 ENV_FILE=$(search_envfile)
 
 if [ "$ENV_FILE" = "" ]; then
+    echo "emacsenv: no environment file found. Run 'emacsenv global <version>' or create a .emacsenvfile" >&2
     exit 1
 fi
 
@@ -8,6 +9,7 @@ EMACS_HOME=""
 . $ENV_FILE
 
 if [ "$EMACS_HOME" = "" ]; then
+    echo "emacsenv: EMACS_HOME is not set in $ENV_FILE" >&2
     exit 1
 fi
 

--- a/bin/emacsenv.d/install.sh
+++ b/bin/emacsenv.d/install.sh
@@ -10,8 +10,8 @@ function finalize() {
 }
 
 if [ ! -e "$LOCAL_REPOSITORY/.git" ]; then
-    echo "install"
-    exit
+    echo "emacsenv: repository not found. Run 'emacsenv setup' first" >&2
+    exit 1
 fi
 
 raw_option="$COMMAND $* $CONFIGURE_OPT"
@@ -29,8 +29,8 @@ DEFAULT_MAKE_OPT="-j4"
 MAKE_OPT=$(or "$MAKE_OPT" "$DEFAULT_MAKE_OPT")
 
 if [ -z "$version" ]; then
-    echo "specify"
-    exit
+    echo "emacsenv: version not specified. Usage: emacsenv install <version>" >&2
+    exit 1
 fi
 
 cd "$LOCAL_REPOSITORY"

--- a/bin/emacsenv.d/plugin.sh
+++ b/bin/emacsenv.d/plugin.sh
@@ -1,4 +1,5 @@
 if [ "$COMMAND" = "" ]; then
+    echo "emacsenv: no command specified. Run 'emacsenv help' for usage" >&2
     exit 1
 fi
 
@@ -11,5 +12,6 @@ fi
 if [ -e "$EMACSENV_PLUGINS_DIR/$COMMAND.sh" ]; then
     . "$EMACSENV_PLUGINS_DIR/$COMMAND.sh"
 else
+    echo "emacsenv: unknown command '$COMMAND'. Run 'emacsenv help' for usage" >&2
     exit 1
 fi

--- a/bin/emacsenv.d/update.sh
+++ b/bin/emacsenv.d/update.sh
@@ -1,4 +1,5 @@
 if [ "$LOCAL_REPOSITORY" = "" ]; then
+    echo "emacsenv: LOCAL_REPOSITORY is not set. Run 'emacsenv setup' first" >&2
     exit 1
 fi
 


### PR DESCRIPTION
Closes #4

## Summary
- exit 1 で異常終了する全箇所に、ユーザー向けのエラーメッセージを追加
- エラーメッセージは stderr に出力（`>&2`）し、`emacsenv: <説明>` の統一フォーマットを使用
- install.sh の曖昧なメッセージ（"install", "specify"）を具体的なエラーメッセージに改善
- install.sh の bare `exit` を `exit 1` に修正して異常終了を明示化

## Changed files
- `bin/emacsenv.d/exec.sh` - 環境ファイル未検出、EMACS_HOME未設定、バイナリ未検出のエラーメッセージ追加
- `bin/emacsenv.d/plugin.sh` - コマンド未指定、不明なコマンドのエラーメッセージ追加
- `bin/emacsenv.d/import.sh` - 環境ファイル未検出、EMACS_HOME未設定のエラーメッセージ追加
- `bin/emacsenv.d/update.sh` - LOCAL_REPOSITORY未設定のエラーメッセージ追加
- `bin/emacsenv.d/env.sh` - 環境ファイル未検出のエラーメッセージ追加
- `bin/emacsenv.d/install.sh` - リポジトリ未検出、バージョン未指定のエラーメッセージ改善
- `bin/emacsenv.d/_functions.sh` - "none action" メッセージを改善し stderr に出力

🤖 Generated with [Claude Code](https://claude.com/claude-code)