### PR TITLE
Fix #8: subcommand install の補完強化

### DIFF
--- a/completions/bash/emacsenv
+++ b/completions/bash/emacsenv
@@ -8,6 +8,18 @@ _emacsenv() {
 
     if [ "$COMP_CWORD" -eq 1 ]; then
         COMPREPLY=($(compgen -W "${subcommands}" -- "${cur}"))
+    elif [ "$COMP_CWORD" -eq 2 ]; then
+        case "$prev" in
+            install)
+                local emacsenv_home="${EMACSENV_HOME:-$HOME/.emacsenv}"
+                local repo_dir="$emacsenv_home/repository"
+                if [ -d "$repo_dir/.git" ]; then
+                    local tags
+                    tags=$(git -C "$repo_dir" tag -l 'emacs-*' --sort=-version:refname)
+                    COMPREPLY=($(compgen -W "${tags}" -- "${cur}"))
+                fi
+                ;;
+        esac
     fi
 }
 

--- a/completions/zsh/_emacsenv
+++ b/completions/zsh/_emacsenv
@@ -18,6 +18,18 @@ _emacsenv() {
 
     if (( CURRENT == 2 )); then
         _describe 'subcommand' subcommands
+    elif (( CURRENT == 3 )); then
+        case "${words[2]}" in
+            install)
+                local emacsenv_home="${EMACSENV_HOME:-$HOME/.emacsenv}"
+                local repo_dir="$emacsenv_home/repository"
+                if [[ -d "$repo_dir/.git" ]]; then
+                    local -a tags
+                    tags=(${(f)"$(git -C "$repo_dir" tag -l 'emacs-*' --sort=-version:refname)"})
+                    _describe 'version' tags
+                fi
+                ;;
+        esac
     fi
 }
 


### PR DESCRIPTION
## Summary
- `emacsenv install` サブコマンドのタブ補完で、利用可能なバージョンタグ (`emacs-*`) を表示するように強化
- `git tag -l 'emacs-*' --sort=-version:refname` を使用し、semantic version の降順でタグを取得
- bash / zsh 両方の補完スクリプトに対応

## Test plan
- [ ] bash で `emacsenv install <TAB>` を実行し、emacs-* タグが補完候補に表示されることを確認
- [ ] zsh で `emacsenv install <TAB>` を実行し、emacs-* タグが補完候補に表示されることを確認
- [ ] `$EMACSENV_HOME/repository` が存在しない場合、補完がエラーにならないことを確認

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)